### PR TITLE
Fix for Headless Functionality

### DIFF
--- a/src/Core/Checkout/PaymentHandler/WeArePlanetPaymentHandler.php
+++ b/src/Core/Checkout/PaymentHandler/WeArePlanetPaymentHandler.php
@@ -10,6 +10,7 @@ use Shopware\Core\{
     Checkout\Payment\Exception\AsyncPaymentFinalizeException,
     Checkout\Payment\Exception\AsyncPaymentProcessException,
     Checkout\Payment\Exception\CustomerCanceledAsyncPaymentException,
+    Checkout\Payment\PaymentException,
     Framework\Validation\DataBag\RequestDataBag,
     System\SalesChannel\SalesChannelContext
 };
@@ -140,7 +141,7 @@ class WeArePlanetPaymentHandler implements AsynchronousPaymentHandlerInterface
                 ]);
                 unset($_SESSION['transactionId']);
                 $this->logger->info($errorMessage);
-                throw new \Exception($transaction->getOrder()->getId());
+                throw PaymentException::customerCanceled($transaction->getOrderTransaction()->getId(), $errorMessage);
             }
         } else {
             $this->orderTransactionStateHandler->paid($transaction->getOrderTransaction()->getId(), $salesChannelContext->getContext());

--- a/src/Core/Storefront/Checkout/Controller/CheckoutController.php
+++ b/src/Core/Storefront/Checkout/Controller/CheckoutController.php
@@ -354,6 +354,19 @@ class CheckoutController extends StorefrontController {
 			throw new MissingRequestParameterException('orderId');
 		}
 
+		// Adoption for Headless Storefronts
+	        $orderRepo = $this->container->get('order.repository');
+	        $criteria = new Criteria([$orderId]);
+	
+	        $orderEntity = $orderRepo->search($criteria, $salesChannelContext->getContext())->first();
+	
+	        if($orderEntity->getSalesChannelId() !== $salesChannelContext->getSalesChannelId()) {
+	            $this->settings = $this->settingsService->getSettings($orderEntity->getSalesChannelId());
+	            $trans = $this->getTransaction($orderId, $salesChannelContext->getContext());
+	            return $this->redirect($trans->getSuccessUrl());
+	        }
+	        // End Adoption for Headless Storefronts
+
 		try {
 			$this->cartService->deleteCart($salesChannelContext);
 			$cart = $this->cartService->createNew($salesChannelContext->getToken());


### PR DESCRIPTION
This Changes enable the possibility of Headless Integration of Weareplanet, because in Headless there is no need for recreate cart.